### PR TITLE
1.1.0 and @1.0 brew formulas for newt and newtmgr

### DIFF
--- a/mynewt-newt.rb
+++ b/mynewt-newt.rb
@@ -1,16 +1,18 @@
 class MynewtNewt < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
-  url "https://github.com/apache/incubator-mynewt-newt/archive/mynewt_1_0_0_tag.tar.gz"
-  version "1.0.0"
-  sha256 "699239691b6fe2e5bb0bb24727cd56740400e6074a369756b890ea7ec290d1bd"
+  url "https://github.com/apache/mynewt-newt/archive/mynewt_1_1_0_tag.tar.gz"
+  version "1.1.0"
+  sha256 "66a90b54034255e073206cc27d9d1a63b76d6dd56a847e4f224a50e3de942aad"
 
-  head "https://github.com/apache/incubator-mynewt-newt.git"
+  head "https://github.com/apache/mynewt-newt.git"
 
   bottle do
-    root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0"
+    root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.1.0"
     cellar :any_skip_relocation
-    sha256 "bbcd73426e3807261102d59687cdf77e369a6d172a61394351c1ffc4ffd27396" => :mavericks_or_later
+    sha256 "68221671cc744d90ae06235e49a8638dd75a36677d27baea7f16ef1482a4127e" => :sierra
+    sha256 "83e119596ffa17c1f828686245428082e0cb4605680c93ea01155994c82595ce" => :el_capitan
+    sha256 "3092023e660ac252c5ad07166f9ea6ebb31f665c4c1d496698b7982de9d9dc08" => :yosemite
   end
 
   depends_on "go" => :build
@@ -31,6 +33,6 @@ class MynewtNewt < Formula
 
   test do
     # Compare newt version string
-    assert_equal "1.0.0", shell_output("#{bin}/newt version").split.last
+    assert_equal "1.1.0", shell_output("#{bin}/newt version").split.last
   end
 end

--- a/mynewt-newt@1.0.rb
+++ b/mynewt-newt@1.0.rb
@@ -1,0 +1,38 @@
+class MynewtNewtAT10 < Formula
+  desc "Package, build and installation system for Mynewt OS applications (1.0)"
+  homepage "https://mynewt.apache.org"
+  url "https://github.com/apache/mynewt-newt/archive/mynewt_1_0_0_tag.tar.gz"
+  version "1.0.0"
+  sha256 "6c39967881357b228c54683c1eaffb47662edbafee7e07c1a27351857a54b5dd"
+
+  bottle do
+    root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0"
+    cellar :any_skip_relocation
+    sha256 "d79f086e378b58b239c4bdf055200bf8d9a85b5068752e4da475999c2d4596fe" => :sierra
+    sha256 "6af9fd1e94593b73ee9fcd6511fcf648005db413a3a6cc76709a8b8c219c5a1f" => :el_capitan
+    sha256 "1ecb25e903ae3dcb35461455babaccf7c061b95a1a95f0bc6b16d646052c4546" => :yosemite
+  end
+   
+  keg_only :versioned_formula
+
+  depends_on "go" => :build
+  depends_on :arch => :x86_64
+
+  def install
+    contents = Dir["{*,.git,.gitignore}"]
+    gopath = buildpath/"gopath"
+    (gopath/"src/mynewt.apache.org/newt").install contents
+    ENV["GOPATH"] = gopath
+    ENV.prepend_create_path "PATH", gopath/"bin"
+
+    cd gopath/"src/mynewt.apache.org/newt/newt" do
+      system "go", "install"
+      bin.install gopath/"bin/newt"
+    end
+  end
+
+  test do
+    # Compare newt version string
+    assert_equal "1.0.0", shell_output("#{bin}/newt version").split.last
+  end
+end

--- a/mynewt-newtmgr.rb
+++ b/mynewt-newtmgr.rb
@@ -1,16 +1,18 @@
 class MynewtNewtmgr < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
-  url "https://github.com/apache/incubator-mynewt-newt/archive/mynewt_1_0_0_tag.tar.gz"
-  version "1.0.0"
-  sha256 "699239691b6fe2e5bb0bb24727cd56740400e6074a369756b890ea7ec290d1bd"
+  url "https://github.com/apache/mynewt-newtmgr/archive/mynewt_1_1_0_tag.tar.gz"
+  version "1.1.0"
+  sha256 "8077d285aaecf61d4d11d45c56640197ad1ff8f9fa93485893c65ee57818ecde"
 
-  head "https://github.com/apache/incubator-mynewt-newt.git"
+  head "https://github.com/apache/mynewt-newtmgr.git"
 
   bottle do
-    root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0"
-    cellar :any_skip_relocation
-    sha256 "a4a8878e5062756d431eaacc383f38a74fb1e28a74198b4fc1ca0c7620936b2e" => :mavericks_or_later
+     root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.1.0"
+     cellar :any_skip_relocation
+     sha256 "37cc3c3bb174ec084bca317eb0a5018e7b489b9c8006e04609b7681820c9ce39" => :sierra
+     sha256 "cefe59d785fc43523e7341c2231690703f885e8510c9ec8f3bee30e6c0943419" => :el_capitan
+     sha256 "1c03414d3f5c821b6040160a6a6c5036cd61f7579075736e57bb305d5fd779f0" => :yosemite
   end
 
   depends_on "go" => :build
@@ -19,11 +21,21 @@ class MynewtNewtmgr < Formula
   def install
     contents = Dir["{*,.git,.gitignore}"]
     gopath = buildpath/"gopath"
-    (gopath/"src/mynewt.apache.org/newt").install contents
+    (gopath/"src/mynewt.apache.org/newtmgr").install contents
     ENV["GOPATH"] = gopath
     ENV.prepend_create_path "PATH", gopath/"bin"
 
-    cd gopath/"src/mynewt.apache.org/newt/newtmgr" do
+# We are not able to vendor these packages due to a "go get" bug in 
+# vendoring packages with platform dependent code. So we have to get
+# these packages for the buid.
+  
+    cd gopath/"src" do
+       system "go", "get", "github.com/currantlabs/ble"
+       system "go", "get", "github.com/raff/goble"
+       system "go", "get", "github.com/mgutz/logxi/v1"
+    end
+
+    cd gopath/"src/mynewt.apache.org/newtmgr/newtmgr" do
       system "go", "install"
       bin.install gopath/"bin/newtmgr"
     end

--- a/mynewt-newtmgr@1.0.rb
+++ b/mynewt-newtmgr@1.0.rb
@@ -1,0 +1,38 @@
+class MynewtNewtmgrAT10 < Formula
+  desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
+  homepage "https://mynewt.apache.org"
+  url "https://github.com/apache/mynewt-newt/archive/mynewt_1_0_0_tag.tar.gz"
+  version "1.0.0"
+  sha256 "6c39967881357b228c54683c1eaffb47662edbafee7e07c1a27351857a54b5dd"
+
+  bottle do
+    root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.0.0"
+    cellar :any_skip_relocation
+    sha256 "63b1be15469ddbacb31ccc10eb0f8314f8248b3c2d94b6e31f1259c361ec2128" => :sierra
+    sha256 "e8b84cca0cd5a92dff33e343ca9de87bdfed51353ccfbeadb8aea6c63704c114" => :el_capitan
+    sha256 "f824ccea8eae3ac293f450d5e0d4d8a4b1e928394f4d979ab740fe67b8c97ec0" => :yosemite
+  end
+
+keg_only :versioned_formula
+
+  depends_on "go" => :build
+  depends_on :arch => :x86_64
+
+  def install
+    contents = Dir["{*,.git,.gitignore}"]
+    gopath = buildpath/"gopath"
+    (gopath/"src/mynewt.apache.org/newt").install contents
+    ENV["GOPATH"] = gopath
+    ENV.prepend_create_path "PATH", gopath/"bin"
+
+    cd gopath/"src/mynewt.apache.org/newt/newtmgr" do
+      system "go", "install"
+      bin.install gopath/"bin/newtmgr"
+    end
+  end
+
+  test do
+    # Check for Newtmgr in first word of output.
+    assert_match "Newtmgr", shell_output("#{bin}/newtmgr").split.first
+  end
+end


### PR DESCRIPTION
**This PR should be merged when the `automated asf-site build` PR, that is created after  PR: https://github.com/apache/mynewt-site/pull/287 is merged, is merged** 
- Updated formulas to 1.1.0.
- Added @1.0 formulas so user can install 1.0.0 newt and newtmgr