### PR TITLE
Resolve Deprecated Style Error

### DIFF
--- a/mynewt-newt.rb
+++ b/mynewt-newt.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewt < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -8,7 +11,7 @@ class MynewtNewt < Formula
   head "https://github.com/apache/mynewt-newt.git"
 
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.0.rb
+++ b/mynewt-newt@1.0.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT10 < Formula
   desc "Package, build and installation system for Mynewt OS applications (1.0)"
   homepage "https://mynewt.apache.org"
@@ -7,16 +10,15 @@ class MynewtNewtAT10 < Formula
 
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.0.0"
-    cellar :any_skip_relocation
-    sha256 "d79f086e378b58b239c4bdf055200bf8d9a85b5068752e4da475999c2d4596fe" => :sierra
-    sha256 "6af9fd1e94593b73ee9fcd6511fcf648005db413a3a6cc76709a8b8c219c5a1f" => :el_capitan
-    sha256 "1ecb25e903ae3dcb35461455babaccf7c061b95a1a95f0bc6b16d646052c4546" => :yosemite
+    sha256 cellar: :any_skip_relocation, sierra:     "d79f086e378b58b239c4bdf055200bf8d9a85b5068752e4da475999c2d4596fe"
+    sha256 cellar: :any_skip_relocation, el_capitan: "6af9fd1e94593b73ee9fcd6511fcf648005db413a3a6cc76709a8b8c219c5a1f"
+    sha256 cellar: :any_skip_relocation, yosemite:   "1ecb25e903ae3dcb35461455babaccf7c061b95a1a95f0bc6b16d646052c4546"
   end
 
   keg_only :versioned_formula
 
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.1.rb
+++ b/mynewt-newt@1.1.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT11 < Formula
   desc "Package, build and installation system for Mynewt OS applications (1.1)"
   homepage "https://mynewt.apache.org"
@@ -7,14 +10,13 @@ class MynewtNewtAT11 < Formula
 
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.1.0"
-    cellar :any_skip_relocation
-    sha256 "c25c240b87978ce246ac1b094dd519a6b6a30e0d09a580d8357b45821eb64923" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "c25c240b87978ce246ac1b094dd519a6b6a30e0d09a580d8357b45821eb64923"
   end
 
   keg_only :versioned_formula
 
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.2.rb
+++ b/mynewt-newt@1.2.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT12 < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtAT12 < Formula
   version "1.2.0"
   sha256 "41e1b7ee526d1861e7b1e880848d090484960a6bafb31bb62d38d25212146736"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.2.0"
-    cellar :any_skip_relocation
-    sha256 "14c58895c9805aa1df17638e483adb8a37fdb6911f96c7e80535fed2fa82ac94" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "14c58895c9805aa1df17638e483adb8a37fdb6911f96c7e80535fed2fa82ac94"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.3.rb
+++ b/mynewt-newt@1.3.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT13 < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtAT13 < Formula
   version "1.3.0"
   sha256 "6fa33e4dae06ff8b6c8788a24b6c29f0587d82dcdc5fe58ea16dcd5078d34076"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.3.0"
-    cellar :any_skip_relocation
-    sha256 "129e38650fa260c50366a40bb62a6546886a1d4713cd47ed2a829b150d5d9813" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "129e38650fa260c50366a40bb62a6546886a1d4713cd47ed2a829b150d5d9813"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.4.rb
+++ b/mynewt-newt@1.4.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT14 < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtAT14 < Formula
   version "1.4.1"
   sha256 "496a5d9fb6e8fb25354cbc7f2aa3507e28e34c980e790ef6c0c4f1cf6d993ec9"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.4.1"
-    cellar :any_skip_relocation
-    sha256 "b5c535039ac48e2ebeb27d74241ea4a3c3b0f8ce08a2bd1043b72acc2ed03408" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "b5c535039ac48e2ebeb27d74241ea4a3c3b0f8ce08a2bd1043b72acc2ed03408"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.5.rb
+++ b/mynewt-newt@1.5.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT15 < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtAT15 < Formula
   version "1.5.0"
   sha256 "c552a0b0eb8a81168abb868856e0ff323d97e433fdb87b7d57cb70de21c5ae1b"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.5.0"
-    cellar :any_skip_relocation
-    sha256 "91d2e93584f79b351c5020e6113dc813171fedbf82a6a3f0656dbffdb4c4ca49" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "91d2e93584f79b351c5020e6113dc813171fedbf82a6a3f0656dbffdb4c4ca49"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.6.rb
+++ b/mynewt-newt@1.6.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT16 < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtAT16 < Formula
   version "1.6.0"
   sha256 "5245fba3d2befc44cd71733dc5c9ae07681cc47d8f79152f439c021d446b7122"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.6.0"
-    cellar :any_skip_relocation
-    sha256 "8dea2947d0cfd60729f5faf17db867ceeae639541849db3e00f380af1a140f3a" => :high_sierra
+    sha256 cellar: :any_skip_relocation, high_sierra: "8dea2947d0cfd60729f5faf17db867ceeae639541849db3e00f380af1a140f3a"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.7.rb
+++ b/mynewt-newt@1.7.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT17 < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtAT17 < Formula
   version "1.7.0"
   sha256 "6aefb5aaae06c4b9d514333ec682f62bd52e97e9d8e7b9f9c50e15983590f1f7"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
-    cellar :any_skip_relocation
-    sha256 "2eb52488b0dd8faf2d6a6764a8ea9d8132625bfae9f599fa23292b4bf5b6679b" => :high_sierra
+    sha256 cellar: :any_skip_relocation, high_sierra: "2eb52488b0dd8faf2d6a6764a8ea9d8132625bfae9f599fa23292b4bf5b6679b"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newt@1.8.rb
+++ b/mynewt-newt@1.8.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtAT18 < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtAT18 < Formula
   version "1.8.0"
   sha256 "9914e614c3d7fcf64ce03fff7918f29711a7c48e35f6057ea0761e27b841339c"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
-    cellar :any_skip_relocation
-    sha256 "f2516115cec9395732f7def32510685a71f5de4348b5fd5618e9788499dc1053" => :big_sur
+    sha256 cellar: :any_skip_relocation, big_sur: "f2516115cec9395732f7def32510685a71f5de4348b5fd5618e9788499dc1053"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newtmgr.rb
+++ b/mynewt-newtmgr.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgr < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -8,13 +11,12 @@ class MynewtNewtmgr < Formula
   head "https://github.com/apache/mynewt-newtmgr.git"
 
   bottle do
-     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
-     cellar :any_skip_relocation
-    sha256 "8f772a9cb14018f268effff2c33c492f1894416178dbb6c390e502c3e91ff6bc" => :high_sierra
+    root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
+    sha256 cellar: :any_skip_relocation, high_sierra: "8f772a9cb14018f268effff2c33c492f1894416178dbb6c390e502c3e91ff6bc"
   end
 
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newtmgr@1.0.rb
+++ b/mynewt-newtmgr@1.0.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT10 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -7,16 +10,15 @@ class MynewtNewtmgrAT10 < Formula
 
   bottle do
     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.0.0"
-    cellar :any_skip_relocation
-    sha256 "63b1be15469ddbacb31ccc10eb0f8314f8248b3c2d94b6e31f1259c361ec2128" => :sierra
-    sha256 "e8b84cca0cd5a92dff33e343ca9de87bdfed51353ccfbeadb8aea6c63704c114" => :el_capitan
-    sha256 "f824ccea8eae3ac293f450d5e0d4d8a4b1e928394f4d979ab740fe67b8c97ec0" => :yosemite
+    sha256 cellar: :any_skip_relocation, sierra:     "63b1be15469ddbacb31ccc10eb0f8314f8248b3c2d94b6e31f1259c361ec2128"
+    sha256 cellar: :any_skip_relocation, el_capitan: "e8b84cca0cd5a92dff33e343ca9de87bdfed51353ccfbeadb8aea6c63704c114"
+    sha256 cellar: :any_skip_relocation, yosemite:   "f824ccea8eae3ac293f450d5e0d4d8a4b1e928394f4d979ab740fe67b8c97ec0"
   end
 
-keg_only :versioned_formula
+  keg_only :versioned_formula
 
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newtmgr@1.1.rb
+++ b/mynewt-newtmgr@1.1.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT11 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol (1.1)"
   homepage "https://mynewt.apache.org"
@@ -6,15 +9,14 @@ class MynewtNewtmgrAT11 < Formula
   sha256 "8077d285aaecf61d4d11d45c56640197ad1ff8f9fa93485893c65ee57818ecde"
 
   bottle do
-     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.1.0"
-     cellar :any_skip_relocation
-     sha256 "5f7cbe8e58c04fdba5b2a7ee142429ebf57802e0c64659585759f231c808c31c" => :sierra
+    root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.1.0"
+    sha256 cellar: :any_skip_relocation, sierra: "5f7cbe8e58c04fdba5b2a7ee142429ebf57802e0c64659585759f231c808c31c"
   end
 
   keg_only :versioned_formula
 
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]
@@ -23,14 +25,14 @@ class MynewtNewtmgrAT11 < Formula
     ENV["GOPATH"] = gopath
     ENV.prepend_create_path "PATH", gopath/"bin"
 
-# We are not able to vendor these packages due to a "go get" bug in 
-# vendoring packages with platform dependent code. So we have to get
-# these packages for the buid.
-  
+    # We are not able to vendor these packages due to a "go get" bug in
+    # vendoring packages with platform dependent code. So we have to get
+    # these packages for the buid.
+
     cd gopath/"src" do
-       system "go", "get", "github.com/currantlabs/ble"
-       system "go", "get", "github.com/raff/goble"
-       system "go", "get", "github.com/mgutz/logxi/v1"
+      system "go", "get", "github.com/currantlabs/ble"
+      system "go", "get", "github.com/raff/goble"
+      system "go", "get", "github.com/mgutz/logxi/v1"
     end
 
     cd gopath/"src/mynewt.apache.org/newtmgr/newtmgr" do

--- a/mynewt-newtmgr@1.2.rb
+++ b/mynewt-newtmgr@1.2.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT12 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtmgrAT12 < Formula
   version "1.2.0"
   sha256 "435c2e66a872bef7b13fbf3cc48add8aba7cb7482849eac234e1499b62c95e6d"
 
-  keg_only :versioned_formula
-
   bottle do
-     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.2.0"
-     cellar :any_skip_relocation
-    sha256 "588884187b39ea39f7e1a900cc89e8f8a029bd20eb6712bc796ca0834145249a" => :sierra
+    root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.2.0"
+    sha256 cellar: :any_skip_relocation, sierra: "588884187b39ea39f7e1a900cc89e8f8a029bd20eb6712bc796ca0834145249a"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]
@@ -23,14 +25,14 @@ class MynewtNewtmgrAT12 < Formula
     ENV["GOPATH"] = gopath
     ENV.prepend_create_path "PATH", gopath/"bin"
 
-# We are not able to vendor these packages due to a "go get" bug in 
-# vendoring packages with platform dependent code. So we have to get
-# these packages for the buid.
-  
+    # We are not able to vendor these packages due to a "go get" bug in
+    # vendoring packages with platform dependent code. So we have to get
+    # these packages for the buid.
+
     cd gopath/"src" do
-       system "go", "get", "github.com/currantlabs/ble"
-       system "go", "get", "github.com/raff/goble"
-       system "go", "get", "github.com/mgutz/logxi/v1"
+      system "go", "get", "github.com/currantlabs/ble"
+      system "go", "get", "github.com/raff/goble"
+      system "go", "get", "github.com/mgutz/logxi/v1"
     end
 
     cd gopath/"src/mynewt.apache.org/newtmgr/newtmgr" do

--- a/mynewt-newtmgr@1.3.rb
+++ b/mynewt-newtmgr@1.3.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT13 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtmgrAT13 < Formula
   version "1.3.0"
   sha256 "6d9b8fd8a89fdef8aa9062ebc9d59b96878641002f85a10baa63756c0968b74e"
 
-  keg_only :versioned_formula
-
   bottle do
-     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.3.0"
-     cellar :any_skip_relocation
-    sha256 "288686fd6a6c169b0b947872274ca2f24721d1ec88d5c7d2ec06db7854012abe" => :sierra
+    root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.3.0"
+    sha256 cellar: :any_skip_relocation, sierra: "288686fd6a6c169b0b947872274ca2f24721d1ec88d5c7d2ec06db7854012abe"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]
@@ -23,14 +25,14 @@ class MynewtNewtmgrAT13 < Formula
     ENV["GOPATH"] = gopath
     ENV.prepend_create_path "PATH", gopath/"bin"
 
-# We are not able to vendor these packages due to a "go get" bug in 
-# vendoring packages with platform dependent code. So we have to get
-# these packages for the buid.
-  
+    # We are not able to vendor these packages due to a "go get" bug in
+    # vendoring packages with platform dependent code. So we have to get
+    # these packages for the buid.
+
     cd gopath/"src" do
-       system "go", "get", "github.com/currantlabs/ble"
-       system "go", "get", "github.com/raff/goble"
-       system "go", "get", "github.com/mgutz/logxi/v1"
+      system "go", "get", "github.com/currantlabs/ble"
+      system "go", "get", "github.com/raff/goble"
+      system "go", "get", "github.com/mgutz/logxi/v1"
     end
 
     cd gopath/"src/mynewt.apache.org/newtmgr/newtmgr" do

--- a/mynewt-newtmgr@1.4.rb
+++ b/mynewt-newtmgr@1.4.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT14 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtmgrAT14 < Formula
   version "1.4.1"
   sha256 "4b77e6f5dad6d94f9aef93b5722789be3293c693c128fe7db6fe78749f3f9568"
 
-  keg_only :versioned_formula
-
   bottle do
     root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.4.1"
-    cellar :any_skip_relocation
-    sha256 "018ce99dcfc7fed1bd567f8082666a885403b4bcadce3234b598398e3544d12c" => :sierra
+    sha256 cellar: :any_skip_relocation, sierra: "018ce99dcfc7fed1bd567f8082666a885403b4bcadce3234b598398e3544d12c"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]
@@ -23,14 +25,14 @@ class MynewtNewtmgrAT14 < Formula
     ENV["GOPATH"] = gopath
     ENV.prepend_create_path "PATH", gopath/"bin"
 
-# We are not able to vendor these packages due to a "go get" bug in 
-# vendoring packages with platform dependent code. So we have to get
-# these packages for the buid.
-  
+    # We are not able to vendor these packages due to a "go get" bug in
+    # vendoring packages with platform dependent code. So we have to get
+    # these packages for the buid.
+
     cd gopath/"src" do
-       system "go", "get", "github.com/currantlabs/ble"
-       system "go", "get", "github.com/raff/goble"
-       system "go", "get", "github.com/mgutz/logxi/v1"
+      system "go", "get", "github.com/currantlabs/ble"
+      system "go", "get", "github.com/raff/goble"
+      system "go", "get", "github.com/mgutz/logxi/v1"
     end
 
     cd gopath/"src/mynewt.apache.org/newtmgr/newtmgr" do

--- a/mynewt-newtmgr@1.5.rb
+++ b/mynewt-newtmgr@1.5.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT15 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtmgrAT15 < Formula
   version "1.5.0"
   sha256 "00bab2c0ea52dab5386b027c92b34936a18ae8ff6a18536db1296fe1e3469832"
 
-  keg_only :versioned_formula
-
   bottle do
-     root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.5.0"
-     cellar :any_skip_relocation
-    sha256 "018522a2ee59181b1f5ecde9db92ff5dee1155042a2fa289f243c5fa4613b337" => :sierra
+    root_url "https://github.com/runtimeco/binary-releases/raw/master/mynewt-newt-tools_1.5.0"
+    sha256 cellar: :any_skip_relocation, sierra: "018522a2ee59181b1f5ecde9db92ff5dee1155042a2fa289f243c5fa4613b337"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]
@@ -23,14 +25,14 @@ class MynewtNewtmgrAT15 < Formula
     ENV["GOPATH"] = gopath
     ENV.prepend_create_path "PATH", gopath/"bin"
 
-# We are not able to vendor these packages due to a "go get" bug in
-# vendoring packages with platform dependent code. So we have to get
-# these packages for the buid.
+    # We are not able to vendor these packages due to a "go get" bug in
+    # vendoring packages with platform dependent code. So we have to get
+    # these packages for the buid.
 
     cd gopath/"src" do
-       system "go", "get", "github.com/currantlabs/ble"
-       system "go", "get", "github.com/raff/goble"
-       system "go", "get", "github.com/mgutz/logxi/v1"
+      system "go", "get", "github.com/currantlabs/ble"
+      system "go", "get", "github.com/raff/goble"
+      system "go", "get", "github.com/mgutz/logxi/v1"
     end
 
     cd gopath/"src/mynewt.apache.org/newtmgr/newtmgr" do

--- a/mynewt-newtmgr@1.6.rb
+++ b/mynewt-newtmgr@1.6.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT16 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtmgrAT16 < Formula
   version "1.6.0"
   sha256 "b85e61ae8a163864d6a25cc9836f52b26c77c51262e0e56c5ea4856577c8805e"
 
-  keg_only :versioned_formula
-
   bottle do
-     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.6.0"
-     cellar :any_skip_relocation
-    sha256 "653580c0726b8f4740fcf71d775efe0758f1eff9fd7c0a6273cede487aad863d" => :high_sierra
+    root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.6.0"
+    sha256 cellar: :any_skip_relocation, high_sierra: "653580c0726b8f4740fcf71d775efe0758f1eff9fd7c0a6273cede487aad863d"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]
@@ -23,14 +25,14 @@ class MynewtNewtmgrAT16 < Formula
     ENV["GOPATH"] = gopath
     ENV.prepend_create_path "PATH", gopath/"bin"
 
-# We are not able to vendor these packages due to a "go get" bug in 
-# vendoring packages with platform dependent code. So we have to get
-# these packages for the buid.
-  
+    # We are not able to vendor these packages due to a "go get" bug in
+    # vendoring packages with platform dependent code. So we have to get
+    # these packages for the buid.
+
     cd gopath/"src" do
-       system "go", "get", "github.com/currantlabs/ble"
-       system "go", "get", "github.com/raff/goble"
-       system "go", "get", "github.com/mgutz/logxi/v1"
+      system "go", "get", "github.com/currantlabs/ble"
+      system "go", "get", "github.com/raff/goble"
+      system "go", "get", "github.com/mgutz/logxi/v1"
     end
 
     cd gopath/"src/mynewt.apache.org/newtmgr/newtmgr" do

--- a/mynewt-newtmgr@1.7.rb
+++ b/mynewt-newtmgr@1.7.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT17 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtmgrAT17 < Formula
   version "1.7.0"
   sha256 "7aaa8c1c6899a9f39957b51e69d02d5c202a58fa104efcdc5bae75d4691b8c2f"
 
-  keg_only :versioned_formula
-
   bottle do
-     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
-     cellar :any_skip_relocation
-    sha256 "8f772a9cb14018f268effff2c33c492f1894416178dbb6c390e502c3e91ff6bc" => :high_sierra
+    root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
+    sha256 cellar: :any_skip_relocation, high_sierra: "8f772a9cb14018f268effff2c33c492f1894416178dbb6c390e502c3e91ff6bc"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]

--- a/mynewt-newtmgr@1.8.rb
+++ b/mynewt-newtmgr@1.8.rb
@@ -1,3 +1,6 @@
+# typed: false
+# frozen_string_literal: true
+
 class MynewtNewtmgrAT18 < Formula
   desc "Tool to manage devices running Mynewt OS via the Newtmgr Protocol"
   homepage "https://mynewt.apache.org"
@@ -5,16 +8,15 @@ class MynewtNewtmgrAT18 < Formula
   version "1.8.0"
   sha256 "9914e614c3d7fcf64ce03fff7918f29711a7c48e35f6057ea0761e27b841339c"
 
-  keg_only :versioned_formula
-
   bottle do
-     root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
-     cellar :any_skip_relocation
-    sha256 "d7abe378aebcca72b7ebdca343b2eb401e5b721762d25b670cf8926aeb543bbf" => :big_sur
+    root_url "https://github.com/JuulLabs-OSS/binary-releases/raw/master/mynewt-newt-tools_1.7.0"
+    sha256 cellar: :any_skip_relocation, big_sur: "d7abe378aebcca72b7ebdca343b2eb401e5b721762d25b670cf8926aeb543bbf"
   end
 
+  keg_only :versioned_formula
+
   depends_on "go" => :build
-  depends_on :arch => :x86_64
+  depends_on arch: :x86_64
 
   def install
     contents = Dir["{*,.git,.gitignore}"]


### PR DESCRIPTION
When attempting to install mynewt using `brew tap JuulLabs-OSS/mynewt` errors are thrown indicating that the syntax needs a style update such as the one shown below:

```
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/juullabs-oss/homebrew-mynewt/mynewt-newtmgr@1.8.rb
mynewt-newtmgr@1.8: Calling `cellar` in a bottle block is disabled! Use `brew style --fix` on the formula to update the style or use `sha256` with a `cellar:` argument instead.
Please report this issue to the juullabs-oss/mynewt tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/juullabs-oss/homebrew-mynewt/mynewt-newtmgr@1.8.rb:12
```

`brew style --fix` was called on the repo to eliminate the errors thrown during the brew tap. 