### PR TITLE
update main mynewt-newt file to install 1.9 instead of 1.8

### DIFF
--- a/mynewt-newt.rb
+++ b/mynewt-newt.rb
@@ -1,9 +1,9 @@
 class MynewtNewt < Formula
   desc "Package, build and installation system for Mynewt OS applications"
   homepage "https://mynewt.apache.org"
-  url "https://github.com/apache/mynewt-newt/archive/mynewt_1_8_0_tag.tar.gz"
-  version "1.8.0"
-  sha256 "9914e614c3d7fcf64ce03fff7918f29711a7c48e35f6057ea0761e27b841339c"
+  url "https://github.com/apache/mynewt-newt/archive/mynewt_1_9_0_tag.tar.gz"
+  version "1.9.0"
+  sha256 "c827986e27167e308f95ce226b04f801dc8f2d862bf7437358e715c0be8f1080"
 
   head "https://github.com/apache/mynewt-newt.git"
 
@@ -23,6 +23,6 @@ class MynewtNewt < Formula
 
   test do
     # Compare newt version string
-    assert_equal "1.7.0", shell_output("#{bin}/newt version").split.last
+    assert_equal "1.9.0", shell_output("#{bin}/newt version").split.last
   end
 end


### PR DESCRIPTION
Installing mynewt via brew will install version 1.8. This change increments the version up to 1.9